### PR TITLE
Fixes in templates (5.1):

### DIFF
--- a/template-app-varnish-cache-active.xml
+++ b/template-app-varnish-cache-active.xml
@@ -5168,7 +5168,7 @@
                             </graph_items>
                         </graph_prototype>
                         <graph_prototype>
-                            <name>Varnish Cache[{#LOCATION}] &gt; Cache Active</name>
+                            <name>Varnish Cache[{#LOCATION}] &gt; Cache</name>
                             <width>900</width>
                             <height>200</height>
                             <yaxismin>0.0000</yaxismin>
@@ -5224,7 +5224,7 @@
                                 <graph_item>
                                     <sortorder>3</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>C800C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>

--- a/template-app-varnish-cache.xml
+++ b/template-app-varnish-cache.xml
@@ -5224,7 +5224,7 @@
                                 <graph_item>
                                     <sortorder>3</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>C800C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>


### PR DESCRIPTION
Changed cache_miss item color from 00C8C8 to C800C8
Deleted one superfluous "Active"