### PR TITLE
Fixes in templates (5.0):

### DIFF
--- a/template-app-varnish-cache-active.xml
+++ b/template-app-varnish-cache-active.xml
@@ -4917,7 +4917,7 @@
                             </graph_items>
                         </graph_prototype>
                         <graph_prototype>
-                            <name>Varnish Cache[{#LOCATION}] &gt; Cache Active</name>
+                            <name>Varnish Cache[{#LOCATION}] &gt; Cache</name>
                             <width>900</width>
                             <height>200</height>
                             <yaxismin>0.0000</yaxismin>
@@ -4961,7 +4961,7 @@
                                 <graph_item>
                                     <sortorder>2</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>0000C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -4973,7 +4973,7 @@
                                 <graph_item>
                                     <sortorder>3</sortorder>
                                     <drawtype>2</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>C800C8</color>
                                     <yaxisside>1</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>

--- a/template-app-varnish-cache.xml
+++ b/template-app-varnish-cache.xml
@@ -4961,7 +4961,7 @@
                                 <graph_item>
                                     <sortorder>2</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>0000C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -4973,7 +4973,7 @@
                                 <graph_item>
                                     <sortorder>3</sortorder>
                                     <drawtype>2</drawtype>
-                                    <color>00C8C8</color>
+                                    <color>C800C8</color>
                                     <yaxisside>1</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>


### PR DESCRIPTION
Changed cache_miss item color from 00C8C8 to 0000C8
Changed cache_hit_ratio item color from 00C8C8 to C800C8
Deleted one superfluous "Active"